### PR TITLE
Fix get_utxo will a lot of blood and tears spilled on it:

### DIFF
--- a/ex1/transaction.py
+++ b/ex1/transaction.py
@@ -8,9 +8,9 @@ class Transaction:
     A transaction with no source creates money. It will only be created by the bank."""
 
     def __init__(self, output: PublicKey, input: Optional[TxID], signature: Signature) -> None:
-        # do not change the name of this field:
+        # Public key of the recipient of the coin
         self.output: PublicKey = output
-        # do not change the name of this field:
+        # Transaction ID of previous transaction
         self.input: Optional[TxID] = input
         # do not change the name of this field:
         self.signature: Signature = signature


### PR DESCRIPTION
the transaction was marked as spent because it the input was none - it should not be the case - in case the bank gives you money. But we need to keep only unique utxo in case it's exact same transaction id, we will need to keep it only once